### PR TITLE
Add new User dashboard.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 services:
   relay:
     container_name: relay
-    image: luxorlabs/relay:v1.0.0
+    image: luxorlabs/relay:v1.0.1
     volumes:
       - vmagentdata:/vmagentdata
       - ./relay/config.toml:/relayproxy.toml

--- a/grafana/dashboards/relay-metrics-user.json
+++ b/grafana/dashboards/relay-metrics-user.json
@@ -1,0 +1,506 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 3,
+    "iteration": 1628699891711,
+    "links": [],
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.3.7",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum by (user) (proxy_worker_up{user=~\"$user\", worker=~\"$worker\"})",
+            "interval": "",
+            "legendFormat": "{{user}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Workers",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 12,
+        "interval": "1m",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.3.7",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum by (user, worker) (increase(session_disconnect_count{user=~\"$user\"}[$__rate_interval]))",
+            "interval": "",
+            "legendFormat": "{{user}} - {{worker}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Workers disconnect",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": true,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "1m minimum intervals stacked bar chart showing proportion of valid, invalid, and stale shares.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "interval": "1m",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null as zero",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": true,
+        "pluginVersion": "7.3.7",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum by (share_type)(increase(backend_outbound_shares{user=~\"$user\", worker=~\"$worker\"}[$__interval])) / ignoring(share_type) group_left sum(increase(backend_outbound_shares{user=~\"$user\", worker=~\"$worker\"}[$__interval]))",
+            "interval": "",
+            "legendFormat": "{{share_type}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Share Validations (backend_outbound_shares)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "unit": "THs"
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "hiddenSeries": false,
+        "id": 8,
+        "interval": "1m",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.3.7",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "(sum by (share_type) (rate(backend_outbound_shares_diff{user=~\"$user\", worker=~\"$worker\"}[$__interval])) * 2 ^ 32 / 1e12) != 0",
+            "interval": "",
+            "legendFormat": "{{share_type}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Total Outbound Hashrate",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "THs",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": false,
+    "schemaVersion": 26,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": "",
+          "current": {
+            "selected": true,
+            "text": [
+              "test-miner"
+            ],
+            "value": [
+              "test-miner"
+            ]
+          },
+          "datasource": "Prometheus",
+          "definition": "label_values(proxy_worker_difficulty, user)",
+          "description": null,
+          "error": null,
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": true,
+          "name": "user",
+          "options": [],
+          "query": "label_values(proxy_worker_difficulty, user)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "selected": true,
+            "tags": [],
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": "Prometheus",
+          "definition": "label_values(proxy_worker_difficulty{user=~\"$user\"}, worker)",
+          "description": null,
+          "error": null,
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": true,
+          "name": "worker",
+          "options": [],
+          "query": "label_values(proxy_worker_difficulty{user=~\"$user\"}, worker)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Luxor Relay Metrics - User",
+    "uid": "relayuser",
+    "version": 1
+  }

--- a/grafana/dashboards/relay-metrics.json
+++ b/grafana/dashboards/relay-metrics.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1624041972362,
+  "iteration": 1628698037132,
   "links": [],
   "panels": [
     {
@@ -52,18 +52,20 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(backend_outbound_shares_diff{share_type=\"valid\",pod=~\"$pod\"}[$__interval])) * 2 ^ 32 / 1e12",
+          "expr": "sum(rate(backend_outbound_shares_diff{share_type=\"valid\"}[$__interval])) * 2 ^ 32 / 1e12",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -118,18 +120,20 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (share_type)(increase(backend_outbound_shares{share_type=\"valid\", pod=~\"$pod\"}[$__range])) / ignoring(share_type) group_left sum(increase(backend_outbound_shares{pod=~\"$pod\"}[$__range]))",
+          "expr": "sum by (share_type)(increase(backend_outbound_shares{share_type=\"valid\"}[$__range])) / ignoring(share_type) group_left sum(increase(backend_outbound_shares[$__range]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -171,18 +175,20 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (backend_name) (backend_up{pod=~\"$pod\"})",
+          "expr": "sum by (backend_name) (backend_up)",
           "interval": "",
           "legendFormat": "{{backend_name}}",
           "refId": "A"
@@ -233,17 +239,19 @@
         "displayMode": "lcd",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
-          "expr": "go_memstats_sys_bytes{pod=~\"$pod\"}",
+          "expr": "go_memstats_sys_bytes",
           "interval": "",
           "legendFormat": "{{job}}",
           "refId": "A"
@@ -302,7 +310,7 @@
         "alertThreshold": true
       },
       "percentage": true,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -313,7 +321,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (share_type)(increase(backend_outbound_shares{pod=~\"$pod\"}[$__interval])) / ignoring(share_type) group_left sum(increase(backend_outbound_shares{pod=~\"$pod\"}[$__interval]))",
+          "expr": "sum by (share_type)(increase(backend_outbound_shares[$__interval])) / ignoring(share_type) group_left sum(increase(backend_outbound_shares[$__interval]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -424,11 +432,11 @@
           }
         ]
       },
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(proxy_worker_up{pod=~\"$pod\"}) without (worker_addr, job, instance, pod) != 0",
+          "expr": "sum(proxy_worker_up) without (worker_addr, job, instance, pod) != 0",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -499,7 +507,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -510,7 +518,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(sum by (backend_name) (rate(backend_outbound_shares_diff{pod=~\"$pod\"}[$__interval]))) * 2 ^ 32 / 1e12",
+          "expr": "(sum by (backend_name) (rate(backend_outbound_shares_diff[$__interval]))) * 2 ^ 32 / 1e12",
           "instant": false,
           "interval": "",
           "legendFormat": "{{backend_name}}",
@@ -560,46 +568,14 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 27,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": [
-      {
-        "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": "Prometheus",
-        "definition": "label_values(backend_up, pod)",
-        "description": null,
-        "error": null,
-        "hide": 0,
-        "includeAll": true,
-        "label": "pod",
-        "multi": true,
-        "name": "pod",
-        "options": [],
-        "query": {
-          "query": "label_values(backend_up, pod)",
-          "refId": "Prometheus-pod-Variable-Query"
-        },
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      }
-    ]
+    "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
This adds a new dashboard for viewing user + worker specific metrics, making it easier to find specific workers.

This also removes the pod variable from the general Relay dashboard since it's unused.